### PR TITLE
It looks like the scene files, like `LandingScene.js` and `ResultScen…

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const gameManager = require('./gameManager');
 const PORT = 3000;
 
 app.use(express.static(__dirname));
+app.use('/scenes', express.static(path.join(__dirname, 'scenes')));
 app.get('/', (req, res) => res.sendFile(path.join(__dirname, 'index.html')));
 
 io.on('connection', socket => {


### PR DESCRIPTION
…e.js`, weren't being served correctly. This was causing HTTP 502 errors in your browser and a `ReferenceError` for `LandingScene` in `game.js` because the file couldn't load. Socket.IO was also reporting a 502 error, which was likely due to the main loading problems.

I've fixed this by adding a specific Express static route in `server.js` to serve files from your `/scenes` directory: `app.use('/scenes', express.static(path.join(__dirname, 'scenes')));`

With this change:
- Requests to `/scenes/*.js` will now correctly find the files in your `scenes` directory.
- `LandingScene.js` and `ResultScene.js` should load successfully.
- The `ReferenceError: LandingScene is not defined` in `game.js` should be resolved.
- The related 502 error for Socket.IO should also be resolved.

I've confirmed that the server starts correctly and all relevant files are served with an HTTP 200 OK status.