### PR TITLE
Fix: Address multiple gameplay and UI issues

### DIFF
--- a/scenes/FinalScoreScene.js
+++ b/scenes/FinalScoreScene.js
@@ -48,9 +48,9 @@ class FinalScoreScene extends Phaser.Scene {
     const staggerDelay = 150; // Delay between each row animation
 
     // Define column X positions
-    const rankX = scoreboardBgX + scoreboardPadding + 15;
-    const avatarX = rankX + 30;
-    const nameX = avatarX + 35;
+    const rankX = scoreboardBgX + scoreboardPadding + 10;
+    const avatarX = rankX + 25;
+    const nameX = avatarX + 20;
     const scoreX = scoreboardBgX + scoreboardBgWidth - scoreboardPadding - 30; // For right aligning score
 
     playersWithScores.forEach((playerEntry, index) => {

--- a/scenes/LandingScene.js
+++ b/scenes/LandingScene.js
@@ -5,88 +5,110 @@ class LandingScene extends Phaser.Scene {
   create() {
     this.cameras.main.setBackgroundColor('#F5F5F5');
 
-    // 🎮 Game Title
-    this.add.text(180, 70, 'Welcome to UnClear 🕵️‍♂️', { // Adjusted Y
-      fontFamily: 'Roboto',
-      fontSize: '32px', // Increased font size
-      color: 'var(--text-color)',
-      fontStyle: 'bold',
-      align: 'center'
-    }).setOrigin(0.5);
+    // Access the global isRejoining flag (set in game.js)
+    if (window.isRejoining === true) {
+      // Display synchronizing message
+      this.add.text(180, 320, 'Synchronizing with server...', {
+        fontFamily: 'Roboto', // Match style
+        fontSize: '20px',
+        color: 'var(--text-color)', // Use CSS variable
+        align: 'center'
+      }).setOrigin(0.5);
+      
+      // Optional: fade in the "Synchronizing" message
+      this.cameras.main.fadeIn(500, 0, 0, 0);
 
-    // ✨ Subtitle
-    this.add.text(180, 115, 'A real-time word guessing game of deception\nand deduction.', { // Adjusted Y
-      fontFamily: 'Roboto',
-      fontSize: '16px',
-      color: 'var(--secondary-accent-color)',
-      align: 'center',
-      lineSpacing: 4
-    }).setOrigin(0.5);
+      // The scene will wait here until 'syncToScene' event (handled in game.js)
+      // transitions it to the correct game scene.
+      console.log('[LandingScene] In rejoining state, waiting for server sync.');
 
-    // 📘 How to Play title
-    this.add.text(180, 170, 'How to Play', { // Adjusted Y
-      fontFamily: 'Roboto',
-      fontSize: '22px', // Increased font size
-      color: 'var(--primary-accent-color)',
-      fontStyle: 'bold',
-      align: 'center'
-    }).setOrigin(0.5);
+    } else {
+      // Proceed with normal landing page setup
+      console.log('[LandingScene] Not rejoining, setting up normal landing page.');
 
-    // 📜 Instructions
-    const instructions = [
-      '• Join a game or host one by leaving the Game ID blank.',
-      '• Everyone gets the same word — except the Imposter.',
-      '• Take turns giving verbal clues based on your word.',
-      '• Vote on the Imposter — score points if correct!'
-    ];
-    this.add.text(180, 260, instructions.join('\n'), { // Adjusted Y and content
+      // 🎮 Game Title
+      this.add.text(180, 70, 'Welcome to UnClear 🕵️‍♂️', { // Adjusted Y
         fontFamily: 'Roboto',
-        fontSize: '15px', // Slightly increased font size
+        fontSize: '32px', // Increased font size
         color: 'var(--text-color)',
-        align: 'left',
-        wordWrap: { width: 300 }, // Adjusted width for bullets
-        lineSpacing: 8 // Increased line spacing
-      }
-    ).setOrigin(0.5); // Centered the block of text
+        fontStyle: 'bold',
+        align: 'center'
+      }).setOrigin(0.5);
 
-    // 🔘 Start Button - Adjust Y position
-    const startBtnY = 330; // Position Start button 
-    const startBtn = this.add.dom(180, startBtnY, 'button', null, 'Start Game').setClassName('button');
-    startBtn.node.style.transform = 'scale(0.8)'; // Initial scale for pop-in via CSS
+      // ✨ Subtitle
+      this.add.text(180, 115, 'A real-time word guessing game of deception\nand deduction.', { // Adjusted Y
+        fontFamily: 'Roboto',
+        fontSize: '16px',
+        color: 'var(--secondary-accent-color)',
+        align: 'center',
+        lineSpacing: 4
+      }).setOrigin(0.5);
 
-    this.tweens.add({
-      targets: startBtn.node, // Target the actual HTML element for DOM tweens
-      scale: 1,
-      ease: 'Back.easeOut',
-      duration: 300,
-      delay: 500 // Delay after difficulty buttons
-    });
-    
-    startBtn.addListener('click');
-    startBtn.on('click', () => {
-      console.log("PLAY_SOUND: click.mp3");
-      this.cameras.main.fadeOut(300, 0, 0, 0, (camera, progress) => {
-        if (progress === 1) {
-          console.log("PLAY_SOUND: transition.mp3");
-          this.scene.start('JoinScene');
+      // 📘 How to Play title
+      this.add.text(180, 170, 'How to Play', { // Adjusted Y
+        fontFamily: 'Roboto',
+        fontSize: '22px', // Increased font size
+        color: 'var(--primary-accent-color)',
+        fontStyle: 'bold',
+        align: 'center'
+      }).setOrigin(0.5);
+
+      // 📜 Instructions
+      const instructions = [
+        '• Join a game or host one by leaving the Game ID blank.',
+        '• Everyone gets the same word — except the Imposter.',
+        '• Take turns giving verbal clues based on your word.',
+        '• Vote on the Imposter — score points if correct!'
+      ];
+      this.add.text(180, 260, instructions.join('\n'), { // Adjusted Y and content
+          fontFamily: 'Roboto',
+          fontSize: '15px', // Slightly increased font size
+          color: 'var(--text-color)',
+          align: 'left',
+          wordWrap: { width: 300 }, // Adjusted width for bullets
+          lineSpacing: 8 // Increased line spacing
         }
+      ).setOrigin(0.5); // Centered the block of text
+
+      // 🔘 Start Button - Adjust Y position
+      const startBtnY = 370; // Position Start button 
+      const startBtn = this.add.dom(180, startBtnY, 'button', null, 'Start Game').setClassName('button');
+      startBtn.node.style.transform = 'scale(0.8)'; // Initial scale for pop-in via CSS
+
+      this.tweens.add({
+        targets: startBtn.node, // Target the actual HTML element for DOM tweens
+        scale: 1,
+        ease: 'Back.easeOut',
+        duration: 300,
+        delay: 500 // Delay after difficulty buttons
       });
-    });
+      
+      startBtn.addListener('click');
+      startBtn.on('click', () => {
+        console.log("PLAY_SOUND: click.mp3");
+        this.cameras.main.fadeOut(300, 0, 0, 0, (camera, progress) => {
+          if (progress === 1) {
+            console.log("PLAY_SOUND: transition.mp3");
+            this.scene.start('JoinScene');
+          }
+        });
+      });
 
-    // 🔁 Subtle Animation (existing hover/pulse for start button)
-    // Keep this if desired, or remove if pop-in is enough entry animation
-    this.tweens.add({
-      targets: startBtn, // This targets the Phaser DOM GameObject wrapper
-      scaleX: 1.04, // Phaser DOM GameObjects are scaled with scaleX, scaleY
-      scaleY: 1.04,
-      duration: 1000,
-      ease: 'Sine.easeInOut',
-      yoyo: true,
-      repeat: -1,
-      delay: 800 // Delay until after pop-in
-    });
+      // 🔁 Subtle Animation (existing hover/pulse for start button)
+      // Keep this if desired, or remove if pop-in is enough entry animation
+      this.tweens.add({
+        targets: startBtn, // This targets the Phaser DOM GameObject wrapper
+        scaleX: 1.04, // Phaser DOM GameObjects are scaled with scaleX, scaleY
+        scaleY: 1.04,
+        duration: 1000,
+        ease: 'Sine.easeInOut',
+        yoyo: true,
+        repeat: -1,
+        delay: 800 // Delay until after pop-in
+      });
 
-    // 🧼 Optional fade-in for the whole screen
-    this.cameras.main.fadeIn(500, 0, 0, 0); // Fade from black
+      // 🧼 Optional fade-in for the whole screen
+      this.cameras.main.fadeIn(500, 0, 0, 0); // Fade from black
+    }
   }
 }


### PR DESCRIPTION
This commit resolves several issues to improve game stability and your experience:

UI Fixes:
- Corrected start button overlap on the landing page by adjusting its Y position.
- Improved spacing on the final scoreboard to prevent player names and scores from overlapping.

Gameplay Logic:
- Resolved the issue where refreshing the page would always return you to the first page. I implemented a scene synchronization mechanism (`rejoinGameCheck` and `syncToScene` events) to restore players to their correct game state and scene.
- Fixed the final scoreboard not appearing automatically by correcting an event name mismatch (server now emits `finalScores` instead of `showFinalScores`, and client handles data correctly).
- Increased clue and voting times to 1 minute (60 seconds) each as requested.
- Made round progression more resilient. The game now checks for active (non-disconnected) players when determining if everyone is ready for the next round, preventing stalls caused by recently disconnected players.

Testing:
- I have outlined a comprehensive plan to cover these changes.